### PR TITLE
Enhance Gantt UI with editing and panning

### DIFF
--- a/gantt-chart-scheduler.html
+++ b/gantt-chart-scheduler.html
@@ -40,7 +40,7 @@
 
     <div class="modal" id="taskModal">
         <div class="modal-content">
-            <h2>新しいタスク</h2>
+            <h2 id="modalTitle">新しいタスク</h2>
             <div class="form-group">
                 <label>タスク名</label>
                 <input type="text" id="taskName" placeholder="タスク名を入力">
@@ -68,7 +68,7 @@
             </div>
             <div class="form-actions">
                 <button class="btn btn-secondary" onclick="closeModal()">キャンセル</button>
-                <button class="btn btn-primary" onclick="addTask()">追加</button>
+                <button class="btn btn-primary" id="taskSubmitBtn" onclick="submitTask()">追加</button>
             </div>
         </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -44,6 +44,11 @@ body {
     overflow: auto;
     position: relative;
     background-color: white;
+    cursor: grab;
+}
+
+.gantt-container.panning {
+    cursor: grabbing;
 }
 
 .timeline-header {
@@ -121,9 +126,20 @@ body {
     background-color: #f8f9fa;
 }
 
-.holiday {
+.date-cell.saturday,
+.grid-line.saturday {
+    background-color: #e3f2fd;
+}
+
+.date-cell.sunday,
+.grid-line.sunday {
     background-color: #ffebee;
-    color: #d32f2f;
+}
+
+.holiday,
+.grid-line.holiday {
+    background-color: #e8f5e9;
+    color: #2e7d32;
 }
 
 .weekday-cell.sunday {
@@ -248,12 +264,10 @@ body {
 }
 
 .grid-line.weekend {
-    background-color: #f8f9fa;
     width: 30px;
 }
 
 .grid-line.holiday {
-    background-color: #ffebee;
     width: 30px;
 }
 


### PR DESCRIPTION
## Summary
- allow task editing through double-click
- keep sidebar and chart in sync while scrolling
- enable drag panning on the chart area
- differentiate weekend and holiday colors
- update modal for both add and edit modes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861ed923c40832e9d574c20e85ff864