### PR TITLE
Fix header gap and dynamic calendar start

### DIFF
--- a/script.js
+++ b/script.js
@@ -67,7 +67,12 @@ let originalStart = null;
 let originalEnd = null;
 let originalWorkDays = 0;
 
-const startDate = new Date('2024-01-01');
+const startDate = (() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    d.setDate(d.getDate() - 7);
+    return d;
+})();
 const cellWidth = 30; // 1日あたりのピクセル幅
 
 const weekdays = ['日', '月', '火', '水', '木', '金', '土'];

--- a/style.css
+++ b/style.css
@@ -153,7 +153,11 @@ body {
 .gantt-grid {
     position: relative;
     min-width: 3000px;
-    padding-top: 90px;
+}
+
+#task-rows {
+    position: relative;
+    margin-top: 90px; /* height of timeline header */
 }
 
 .task-row {


### PR DESCRIPTION
## Summary
- remove excess gap above date row
- keep tasks below header
- start calendar seven days before today

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861f0991548832eaaf3d00284734212