### PR TITLE
Update Gantt chart timeline and weekend coloring

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
             <div class="gantt-container">
                 <div class="gantt-grid" id="gantt-grid">
                     <div class="timeline-header">
-                        <div class="month-row" id="month-row"></div>
                         <div class="weekday-row" id="weekday-row"></div>
                         <div class="date-row" id="date-row"></div>
                     </div>

--- a/script.js
+++ b/script.js
@@ -121,10 +121,8 @@ function addWorkDays(start, workDays) {
 
 // タイムラインヘッダーの描画
 function renderTimeline() {
-    const monthRow = document.getElementById('month-row');
     const weekdayRow = document.getElementById('weekday-row');
     const dateRow = document.getElementById('date-row');
-    monthRow.innerHTML = '';
     weekdayRow.innerHTML = '';
     dateRow.innerHTML = '';
 
@@ -132,32 +130,12 @@ function renderTimeline() {
     document.querySelectorAll('.grid-line').forEach(line => line.remove());
 
     const endDate = new Date(startDate);
-    endDate.setFullYear(endDate.getFullYear() + 1);
-
-    let currentMonth = -1;
-    let monthStartIndex = 0;
-    let daysInCurrentMonth = 0;
+    endDate.setDate(endDate.getDate() + 365);
 
     for (let d = new Date(startDate); d < endDate; d.setDate(d.getDate() + 1)) {
-        const month = d.getMonth();
         const date = d.getDate();
         const dayOfWeek = d.getDay();
         const dateStr = d.toISOString().split('T')[0];
-
-        // 月の表示
-        if (month !== currentMonth) {
-            if (currentMonth !== -1) {
-                const monthCell = document.createElement('div');
-                monthCell.className = 'month-cell';
-                monthCell.style.width = (daysInCurrentMonth * cellWidth) + 'px';
-                monthCell.textContent = new Date(d.getFullYear(), currentMonth).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long' });
-                monthRow.appendChild(monthCell);
-            }
-            currentMonth = month;
-            monthStartIndex = dateRow.children.length;
-            daysInCurrentMonth = 0;
-        }
-        daysInCurrentMonth++;
 
         // 曜日の表示
         const weekdayCell = document.createElement('div');
@@ -205,14 +183,7 @@ function renderTimeline() {
         document.getElementById('task-rows').appendChild(gridLine);
     }
 
-    // 最後の月を追加
-    if (daysInCurrentMonth > 0) {
-        const monthCell = document.createElement('div');
-        monthCell.className = 'month-cell';
-        monthCell.style.width = (daysInCurrentMonth * cellWidth) + 'px';
-        monthCell.textContent = new Date(endDate.getFullYear(), currentMonth).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long' });
-        monthRow.appendChild(monthCell);
-    }
+    // 月表示は不要なので何もしない
 }
 
 // 祝日の切り替え

--- a/style.css
+++ b/style.css
@@ -58,7 +58,7 @@ body {
     border-bottom: 2px solid #bdc3c7;
     z-index: 10;
     display: flex;
-    height: 90px;
+    height: 60px;
 }
 
 .month-row {
@@ -74,7 +74,7 @@ body {
     height: 30px;
     display: flex;
     position: absolute;
-    top: 30px;
+    top: 0;
     left: 0;
     right: 0;
 }
@@ -83,7 +83,7 @@ body {
     height: 30px;
     display: flex;
     position: absolute;
-    top: 60px;
+    top: 30px;
     left: 0;
     right: 0;
 }
@@ -157,7 +157,7 @@ body {
 
 #task-rows {
     position: relative;
-    margin-top: 90px; /* height of timeline header */
+    margin-top: 60px; /* height of timeline header */
 }
 
 .task-row {
@@ -267,10 +267,8 @@ body {
     pointer-events: none;
 }
 
-.grid-line.weekend {
-    width: 30px;
-}
-
+.grid-line.saturday,
+.grid-line.sunday,
 .grid-line.holiday {
     width: 30px;
 }


### PR DESCRIPTION
## Summary
- remove month row from timeline
- show a 365-day range
- adjust header heights and spacing
- color weekend chart columns fully

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861f47cb884832e8699148a66c3acd4